### PR TITLE
Remove IO by deleting Main and rename Lib to Pdepreludat

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,0 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-module Main where
-
-import Lib
-
-main :: IO ()
-main = someFunc

--- a/package.yaml
+++ b/package.yaml
@@ -25,17 +25,6 @@ dependencies:
 library:
   source-dirs: src
 
-executables:
-  pdeprelude-exe:
-    main:                Main.hs
-    source-dirs:         app
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
-    dependencies:
-    - pdeprelude
-
 tests:
   pdeprelude-test:
     main:                Spec.hs

--- a/src/PdePreludat.hs
+++ b/src/PdePreludat.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DataKinds, TypeOperators, UndecidableInstances, FlexibleInstances, ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-module Lib (
+module PdePreludat (
     (/),
-    someFunc,
     module Prelude,
     concat,
     length,
@@ -30,9 +29,6 @@ import Prelude hiding ((/), concat, length, elem, sum, product, null,
 import qualified Prelude as P
 import GHC.TypeLits
 import Data.Typeable
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"
 
 -- Reemplazos para Foldable
 length :: [a] -> Int

--- a/the-template/app/Main.hs
+++ b/the-template/app/Main.hs
@@ -1,6 +1,0 @@
-module Main where
-
-import Lib
-
-main :: IO ()
-main = return ()

--- a/the-template/package.yaml
+++ b/the-template/package.yaml
@@ -29,17 +29,6 @@ default-extensions:
 library:
   source-dirs: src
 
-executables:
-  the-template-exe:
-    main:                Main.hs
-    source-dirs:         app
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
-    dependencies:
-    - the-template
-
 tests:
   the-template-test:
     main:                Spec.hs

--- a/the-template/src/Library.hs
+++ b/the-template/src/Library.hs
@@ -1,6 +1,4 @@
-module Library
-    ( someFunc1
-    ) where
+module Library where
 import PdePreludat
 
 someFunc1 :: Int

--- a/the-template/src/Library.hs
+++ b/the-template/src/Library.hs
@@ -1,8 +1,7 @@
 module Library
     ( someFunc1
     ) where
-
-import Lib
+import PdePreludat
 
 someFunc1 :: Int
 someFunc1 = 42

--- a/the-template/test/Spec.hs
+++ b/the-template/test/Spec.hs
@@ -1,4 +1,4 @@
-import Lib
+import PdePreludat
 import Library
 import Test.Hspec
 


### PR DESCRIPTION
# Qué
Creo que a los alumnos les podría confundir un poco ver un archivo `Main.hs` con una función `main` de un tipo que para ellos es extraño (`IO ()`), entonces, la idea de este PR es bajar las ocurrencias de IO y dejar solo IO para los tests.

# Cómo
Sólo eliminar el `Main.hs` provoca un error en stack, también hay que sacar de la configuración de stack el ejecutable, dejando solo library y test.
Aproveché también para renombrar el módulo a Pdepreludat.

## Nota
Este cambio tiene un efecto inesperado que no entiendo muy bien como pasa que es que en el Prelude aparece dos veces el nombre del modulo como se ve acá:

```
[1 of 1] Compiling Pdepreludat      ( /home/juan/Development/Proyectos/10pines/greenhouse-haskell/pdeprelude/src/Pdepreludat.hs, interpreted )
Ok, one module loaded.
Loaded GHCi configuration from /tmp/haskell-stack-ghci/102ec5c3/ghci-script
*Pdepreludat Pdepreludat> 
```

Me parece algo medio menor, aún así agregué al template un .ghci que es un archivo de configuración que se usa al ejecutar `stack ghci`, pero al menos en ubuntu no lo toma de una porque `stack new` a partir del template lo crea con ciertos permisos, y ghci necesita que tenga menos permisos para leer el .ghci bien.