### PR TITLE
Adding circleci file + all cabal files

### DIFF
--- a/pdepreludat.hsfiles
+++ b/pdepreludat.hsfiles
@@ -154,7 +154,7 @@ main = hspec $ do
 
 {-# START_FILE .gitignore #-}
 .stack-work/
-{{name}}.cabal
+*.cabal
 *~
 .history
 {-# START_FILE ChangeLog.md #-}
@@ -197,6 +197,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 {-# START_FILE README.md #-}
 # ejercicio-alumno
 
+## Integrantes
+
+- integrante1 (usuario github)
+- integrante2 (usuario github)
+...
+
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
 main = defaultMain
@@ -227,3 +233,34 @@ install:
 script:
   - stack --no-terminal test --haddock --no-haddock-deps
 
+{-# START_FILE .circleci/config.yml #-}
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian:stretch
+
+    steps:
+      - run:
+          name: APT dependencies
+          command: apt-get update && apt-get install -y libgmp-dev curl build-essential netbase git
+
+      - run:
+          name: Install Stack
+          command: |
+            mkdir -p ~/.local/bin
+            curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+      - checkout
+
+      - run:
+          name: Setup project dependencies
+          command: |
+            export PATH=$HOME/.local/bin:$PATH
+            stack --no-terminal --install-ghc test --only-dependencies
+
+      - run:
+          name: Project tests
+          command: |
+            export PATH=$HOME/.local/bin:$PATH
+            stack --no-terminal test --haddock --no-haddock-deps


### PR DESCRIPTION
hola @JuanFdS ! Este PR tenemos que mergearlo cuanto antes para que los chicos trabajen con CI de Circle.
    
hoy estuve jugando con CircleCI, por eso agrego .circleci/config.yml en los archivos a generar. También me di cuenta de que tengo que ignorar cualquier archivo cabal, porque el nombre del archivo cabal no es el que genero en la kata, sino el del repo privado que genera cada uno de los chicos, por ejemplo:

mn-funcional-kata-00 como repo público se transforma en
kata-1-pepito
kata-1-daiana
etc. según el usuario de github de cada alumno, y eso tira un warning cuando les pedimos que hagan stack build intero.

Respecto a CI: no pude hacer andar el badge con repos privados, solo me andan si son públicos los repos, pero no me calienta. Lo único que me falta investigar en algún momento son los caches, pero el build tarda entre 2 y 3 minutos, no me parece mal.
