### PR TITLE
Rename Lib to PdePreludat

### DIFF
--- a/src/PdePreludat.hs
+++ b/src/PdePreludat.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds, TypeOperators, UndecidableInstances, FlexibleInstances, ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-module Lib (
+module PdePreludat (
     (/),
     module Prelude,
     concat,

--- a/the-template/src/Library.hs
+++ b/the-template/src/Library.hs
@@ -1,5 +1,5 @@
 module Library where
-import Lib
+import PdePreludat
 
 someFunc1 :: Int
 someFunc1 = 42


### PR DESCRIPTION
Lib y Library son muy parecidas, así que sugiero renombrar Lib a PdePreludat así es menos confuso.