### PR TITLE
Change strategy to solve students' problems with integrals and fractionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Se definió una instancia de `Show` para las funciones
 <una función>
 ```
 
-## División entre fracciones y enteros
+## Operaciones entre fracciones y enteros
 
-Se reemplazó la división entre `Fractional`s (/) para que no sea un error de tipos dividir `Integral`s con `Fractional`s
+Se agregó la función `toFloat` para convertir enteros a decimales, ya que creemos que `fromIntegral` puede ser un poco confuso de usar, y se agregaron mejores mensajes de error a las operaciones donde se esperaba un decimal y llegó un entero o viceversa.
 
 ### Antes
 
@@ -61,7 +61,10 @@ Se reemplazó la división entre `Fractional`s (/) para que no sea un error de t
 
 ```haskell
 > sum [1,2] / length [1,2]
-1.5
+<interactive>:1:1: error:
+    • Estás operando enteros con fraccionales, que son diferentes tipos. Podés convertir el entero en decimal usando toFloat/1 o el decimal en entero usando round/1, floor/1 o ceiling/1.
+    • In the expression: sum [1, 2] / length [1, 2]
+      In an equation for ‘it’: it = sum [1, 2] / length [1, 2]
 ```
 
 ## Mensajes de error al operar funciones o listas

--- a/src/PdePreludat.hs
+++ b/src/PdePreludat.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE DataKinds, TypeOperators, UndecidableInstances, FlexibleInstances, ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds, TypeOperators, UndecidableInstances, FlexibleInstances, ScopedTypeVariables, MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module PdePreludat (
-    (/),
     module Prelude,
     concat,
     length,
@@ -24,10 +23,11 @@ module PdePreludat (
     implementame,
     arreglame,
     (...),
-    size
+    size,
+    toFloat
 ) where 
 
-import Prelude hiding ((/), concat, length, elem, sum, product, null,
+import Prelude hiding (concat, length, elem, sum, product, null,
                        foldr, foldr1, foldl, foldl1, maximum, minimum,
                        all, any, and, or, concatMap, notElem)
 import qualified Prelude as P
@@ -93,24 +93,6 @@ notElem = P.notElem
 instance Show (a -> b) where
     show _ = "<una función>"
 
-class Fractionable a where
-    toFractional :: (Fractional b) => a -> b
-
-instance Fractionable Int where
-    toFractional entero = fromIntegral entero
-
-instance Fractionable Integer where
-    toFractional entero = fromIntegral entero
-
-instance Fractionable Double where
-    toFractional = fromRational . toRational
-
-instance Fractionable Float where
-    toFractional = fromRational . toRational
-
-(/) :: (Fractionable a, Fractionable b, Fractional c) => a -> b -> c
-a / b = toFractional a P./ toFractional b
-
 -- TODO: intentar hacer funcionar esto para filter
 -- instance (Typeable a, Typeable b) => Show (a -> b) where
 --     show _ = "Una función de tipo: "
@@ -163,6 +145,15 @@ instance TypeError ErrorNumeroXCaracter => RealFrac Char
 instance TypeError ErrorNumeroXCaracter => RealFloat Char
 instance TypeError ErrorNumeroXCaracter => Real Char
 
+--Errores entre enteros y fraccionales
+type ErrorFraccionalXEntero =
+    Text "Estás operando enteros con fraccionales, que son diferentes tipos. Podés convertir el entero en decimal usando toFloat/1 o el decimal en entero usando round/1, floor/1 o ceiling/1."
+
+instance TypeError ErrorFraccionalXEntero => Fractional Int
+instance TypeError ErrorFraccionalXEntero => Fractional Integer
+instance TypeError ErrorFraccionalXEntero => Integral Float
+instance TypeError ErrorFraccionalXEntero => Integral Double
+
 (...) :: a
 (...) = error "Falta implementar."
 
@@ -174,3 +165,6 @@ arreglame = (...)
 
 size :: [a] -> Int
 size = length
+
+toFloat :: Integral a => a -> Float
+toFloat = fromIntegral

--- a/the-template/src/Library.hs
+++ b/the-template/src/Library.hs
@@ -3,3 +3,6 @@ import PdePreludat
 
 someFunc1 :: Int
 someFunc1 = 42
+
+unoComaCinco :: Float
+unoComaCinco = (3/2)


### PR DESCRIPTION
# Problem

Before, we were trying to make division between integrals and fractionals transparent to the students by using a typeclass of our own (Fractionable) which supported converting Int, Integer, Float and Double to Float. That way we were able to implement (/) in a way that `1 :: Int / 2 :: Float` would type. The problem with this is that some definitions could be ambiguous, for example:
```haskell
Float -> Float
half :: (/2)
```
What's the 2 there? It could be an Int, and Integer, a Float or a Double and it'd be valid, and since the type of (/) is a -> b -> c, we don't give the compiler enough information to deduce it, and it fails with an ambiguous type error.

# Solution
Keep the division from the Prelude instead of redefining it, add a function to convert integrals to Floats (since we think that fromIntegral may be a bit conterintuitive to beginners) and add custom type errors instances for `Integral Float`, `Integral Double`, `Fractional Int`, `Fractional Integer`.
This way, the students will still get type errors when doing things like `length [1,2,3] / 3`, but we think they will be more likely to solve the type error.