### PR TITLE
Round numbers to avoid floating point problems

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,3 +48,4 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - pdeprelude
+    - hspec

--- a/pdeprelude.cabal
+++ b/pdeprelude.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 666f205e0c9bdf43d841926b200de04da8bdb98a3ce82ee972f6ddf4360c38a6
+-- hash: 983135630b3d059bec5924aceb372f8767d1a8694efbe286ce54ba1c5ade2fa5
 
 name:           pdeprelude
 version:        0.2.0.0
@@ -53,5 +53,6 @@ test-suite pdeprelude-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , hspec
     , pdeprelude
   default-language: Haskell2010

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -11,10 +11,11 @@ type WrappedNum = P.Double
 -- Funciones para convertir entre Number y los Num del Prelude
 
 numberToIntegral :: (P.Integral a) => Number -> a
-numberToIntegral (Number number) | isFractional roundedNumber = P.error "Se esperaba un valor entero pero se pasó uno con decimales"
+numberToIntegral (Number number) | isFractional roundedNumber = P.error notAnIntegralErrorMessage
                                  | P.otherwise = P.floor roundedNumber
     where isFractional numero = P.floor numero P./= P.ceiling numero
           roundedNumber = roundWrappedNum number
+          notAnIntegralErrorMessage = "Se esperaba un valor entero pero se pasó uno con decimales: " P.++ P.show (Number number)
 
 numberToFractional :: (P.Fractional a) => Number -> a
 numberToFractional = P.realToFrac

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -1,9 +1,9 @@
 module Number where 
 
-import Prelude (($))
+import Prelude (($), (.))
 import qualified Prelude as P
 
-newtype Number = Number P.Double deriving (P.Show, P.Eq, P.Ord, P.Num, P.RealFrac, P.Real, P.Fractional, P.Enum, P.Floating) via P.Double
+newtype Number = Number P.Double deriving (P.RealFrac, P.Num, P.Real, P.Fractional, P.Enum, P.Floating) via P.Double
 
 -- Funciones para convertir entre Number y los Num del Prelude
 
@@ -31,3 +31,24 @@ fromInteger = P.fromInteger
 
 fromRational :: P.Rational -> Number
 fromRational = P.fromRational
+
+-- Redondeos para evitar los errores que pueden surgir de trabajar con numeros de punto flotante
+
+roundNumber :: (P.Fractional a, P.RealFrac a) => a -> a
+roundNumber = roundingTo $ numberToIntegral (numberToFractional digitsAfterComma)
+
+digitsAfterComma :: Number
+digitsAfterComma = 9
+
+roundingTo :: (P.Integral b, P.Fractional a, P.RealFrac a) => b -> a -> a
+roundingTo n = (P./ exp) . P.fromIntegral . P.round . (P.* exp)
+    where exp = (numberToFractional 10) P.^ n
+
+instance P.Ord Number where
+    compare (Number a) (Number b) = P.compare (roundNumber a) (roundNumber b)
+
+instance P.Eq Number where
+    Number a == Number b = roundNumber a P.== roundNumber b
+
+instance P.Show Number where
+    show (Number x) = P.show $ roundNumber x

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -1,4 +1,11 @@
-module Number where 
+module Number (Number,
+               fromInteger,
+               fromRational,
+               integralToNumber,
+               numberToFractional,
+               numberToIntegral,
+               integerToNumber,
+               numberToFloat) where 
 
 import Prelude (($), (.))
 import qualified Prelude as P

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -3,14 +3,18 @@ module Number where
 import Prelude (($), (.))
 import qualified Prelude as P
 
-newtype Number = Number P.Double deriving (P.RealFrac, P.Num, P.Real, P.Fractional, P.Enum, P.Floating) via P.Double
+newtype Number = Number { wrappedNum :: WrappedNum }
+    deriving (P.RealFrac, P.Num, P.Real, P.Fractional, P.Enum, P.Floating) via WrappedNum
+
+type WrappedNum = P.Double
 
 -- Funciones para convertir entre Number y los Num del Prelude
 
 numberToIntegral :: (P.Integral a) => Number -> a
-numberToIntegral n | isFractional n = P.error "Se esperaba un valor entero pero se pasó uno con decimales"
-                   | P.otherwise = P.floor n
+numberToIntegral (Number number) | isFractional roundedNumber = P.error "Se esperaba un valor entero pero se pasó uno con decimales"
+                                 | P.otherwise = P.floor roundedNumber
     where isFractional numero = P.floor numero P./= P.ceiling numero
+          roundedNumber = roundWrappedNum number
 
 numberToFractional :: (P.Fractional a) => Number -> a
 numberToFractional = P.realToFrac
@@ -34,21 +38,21 @@ fromRational = P.fromRational
 
 -- Redondeos para evitar los errores que pueden surgir de trabajar con numeros de punto flotante
 
-roundNumber :: (P.Fractional a, P.RealFrac a) => a -> a
-roundNumber = roundingTo $ numberToIntegral (numberToFractional digitsAfterComma)
+roundWrappedNum :: WrappedNum -> WrappedNum
+roundWrappedNum = roundingTo digitsAfterComma
 
-digitsAfterComma :: Number
-digitsAfterComma = 9
+digitsAfterComma :: P.Integer
+digitsAfterComma = P.round $ wrappedNum 9.0
 
-roundingTo :: (P.Integral b, P.Fractional a, P.RealFrac a) => b -> a -> a
+roundingTo :: P.Integer -> WrappedNum -> WrappedNum
 roundingTo n = (P./ exp) . P.fromIntegral . P.round . (P.* exp)
     where exp = (numberToFractional 10) P.^ n
 
 instance P.Ord Number where
-    compare (Number a) (Number b) = P.compare (roundNumber a) (roundNumber b)
+    compare (Number a) (Number b) = P.compare (roundWrappedNum a) (roundWrappedNum b)
 
 instance P.Eq Number where
-    Number a == Number b = roundNumber a P.== roundNumber b
+    Number a == Number b = roundWrappedNum a P.== roundWrappedNum b
 
 instance P.Show Number where
-    show (Number x) = P.show $ roundNumber x
+    show (Number x) = P.show $ roundWrappedNum x

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,6 +23,8 @@ main = hspec $
         (1 / 3) `shouldBeTheSameNumberAs` 0.333333333
       it "no se pierde informacion al redondear en sucesivas operaciones" $ do
         (1 / 3 * 3) `shouldBeTheSameNumberAs` 1
+      it "se redondea al usarse como parámetro de funciones que necesitan enteros" $ do
+        take 0.9999999999 [1,2,3,4] `shouldBe` [1]
 
 shouldBeTheSameNumberAs :: Number -> Number -> Expectation
 shouldBeTheSameNumberAs aNumber anotherNumber =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,33 @@
+module Main where
 import PdePreludat
+import Test.Hspec
+import Control.Exception (evaluate)
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec $
+  describe "Number" $ do
+    it "dividir por 0 lanza error" $ do
+      shouldThrowError $ 1 / 0
+    describe "redondea a 9 decimales para compensar errores de punto flotante" $ do
+      it "los numeros con muchos decimales se muestran redondeados" $ do
+        show 0.9999999999 `shouldBe` "1.0"
+      it "los decimales literales se redondean" $ do
+        0.9999999999 `shouldBeTheSameNumberAs` 1
+      it "los resultados de sumas se redondean" $ do
+        (0.1 + 0.7) `shouldBeTheSameNumberAs` 0.8
+      it "los resultados de restas se redondean" $ do
+        (0.8 - 0.1) `shouldBeTheSameNumberAs` 0.7
+      it "los resultados de multiplicaciones se redondean" $ do
+        (0.1 * 3) `shouldBeTheSameNumberAs` 0.3
+      it "los resultados de divisiones se redondean" $ do
+        (1 / 3) `shouldBeTheSameNumberAs` 0.333333333
+      it "no se pierde informacion al redondear en sucesivas operaciones" $ do
+        (1 / 3 * 3) `shouldBeTheSameNumberAs` 1
+
+shouldBeTheSameNumberAs :: Number -> Number -> Expectation
+shouldBeTheSameNumberAs aNumber anotherNumber =
+  (aNumber `shouldBe` anotherNumber) <>
+  (aNumber < anotherNumber `shouldBe` False) <>
+  (aNumber > anotherNumber `shouldBe` False)
+
+shouldThrowError expresion = evaluate expresion `shouldThrow` anyException


### PR DESCRIPTION
Hay algunas operaciones como 0.1 + 0.7 que devuelven resultados raros como 0.7999999999999999

Esto no se lleva bien con que haya funciones que solo tienen sentido para enteros (como `even` o `take`), así que esto está causando algunos problemas.

La idea de este PR es redondear los numeros a 9 digitos para reducir ese comportamiento "inespereado" que surge por usar numeros de punto flotante.

La forma de encararlo no es directamente redondeando los numeros a medida que son resultados de operaciones, si no redondear los numeros cuando van a ser comparados. Entonces, se está redondeando solo en las funciones de las typeclasses Ord, Eq y Show.
Eq para que expresiones como `0.1 + 0.7 == 0.8` sean verdad (aunque también va a seguir siendo verdad que `0.1 + 0.7 == 0.7999999999999999`.
Ord para mantener consistencia, porque con solo Eq pasa que `0.1 + 0.7 == 0.8` es True, pero tambien sería True `0.1 + 0.7 < 0.8`.
Show es para mostrar al usuario el valor redondeado porque ver 0.7999999999999999 podría desconcertar al alumno (?

Esto seguro que tiene errores. Por ejemplo, como en realidad no estamos perdiendo nada de informacion del Double que está siendo wrappeado, supongo que podrían stackearse suficientes digitos a los que no les damos bola en sucesivas operaciones sin que nos demos cuenta y en algún momento lleguen a cambiar el valor redondeado.

Si se les ocurren cosas que podrían salir terriblemente mal por mergear esto avisen `:P`