### PR TITLE
Add ifThenElse

### DIFF
--- a/src/PdePreludat.hs
+++ b/src/PdePreludat.hs
@@ -5,6 +5,7 @@ module PdePreludat (
     implementame,
     arreglame,
     (...),
+    ifThenElse,
 ) where
 
 -- Estos modulos solo exportan instancias de typeclasses, que se exportan por default asi que no es necesario reexportarlos
@@ -21,6 +22,17 @@ import Prelude (Ord(..), Eq(..), Show(..), Enum(..), Bool(..), ($), (&&), (++), 
 
 -- Este modulo no se reexporta, solo se importo para definir funciones en base a las definidas ahí.
 import qualified Prelude as P
+
+-- RebindableSyntax hace necesario que tengamos que definir ifThenElse si queremos
+-- usar el patron if condicion then algo else otraCosa
+
+ifThenElse :: Bool -> a -> a -> a
+ifThenElse condition ifTrue ifFalse = case condition of
+  True -> ifTrue
+  False -> ifFalse
+
+-- Valor pensado para usarla como implementación por defecto de funciones
+-- o valores que pidamos que sean implementados en los ejercicios
 
 (...) :: a
 (...) = P.error "Falta implementar."

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,27 +4,34 @@ import Test.Hspec
 import Control.Exception (evaluate)
 
 main :: IO ()
-main = hspec $
-  describe "Number" $ do
-    it "dividir por 0 lanza error" $ do
-      shouldThrowError $ 1 / 0
-    describe "redondea a 9 decimales para compensar errores de punto flotante" $ do
-      it "los numeros con muchos decimales se muestran redondeados" $ do
-        show 0.9999999999 `shouldBe` "1.0"
-      it "los decimales literales se redondean" $ do
-        0.9999999999 `shouldBeTheSameNumberAs` 1
-      it "los resultados de sumas se redondean" $ do
-        (0.1 + 0.7) `shouldBeTheSameNumberAs` 0.8
-      it "los resultados de restas se redondean" $ do
-        (0.8 - 0.1) `shouldBeTheSameNumberAs` 0.7
-      it "los resultados de multiplicaciones se redondean" $ do
-        (0.1 * 3) `shouldBeTheSameNumberAs` 0.3
-      it "los resultados de divisiones se redondean" $ do
-        (1 / 3) `shouldBeTheSameNumberAs` 0.333333333
-      it "no se pierde informacion al redondear en sucesivas operaciones" $ do
-        (1 / 3 * 3) `shouldBeTheSameNumberAs` 1
-      it "se redondea al usarse como parámetro de funciones que necesitan enteros" $ do
-        take 0.9999999999 [1,2,3,4] `shouldBe` [1]
+main = hspec $ do
+  describe "Pdepreludat" $ do
+    describe "expresion if then else" $ do
+      it "si la condicion del if es verdadera, devuelve el valor del then" $ do
+        (if 2 == 2 then "Then" else "Else") `shouldBe` "Then"
+      it "si la condicion del if es falsa, devuelve el valor del else" $ do
+        (if 2 == 3 then 1 else 0) `shouldBe` 0
+
+    describe "Number" $ do
+      it "dividir por 0 lanza error" $ do
+        shouldThrowError $ 1 / 0
+      describe "redondea a 9 decimales para compensar errores de punto flotante" $ do
+        it "los numeros con muchos decimales se muestran redondeados" $ do
+          show 0.9999999999 `shouldBe` "1.0"
+        it "los decimales literales se redondean" $ do
+          0.9999999999 `shouldBeTheSameNumberAs` 1
+        it "los resultados de sumas se redondean" $ do
+          (0.1 + 0.7) `shouldBeTheSameNumberAs` 0.8
+        it "los resultados de restas se redondean" $ do
+          (0.8 - 0.1) `shouldBeTheSameNumberAs` 0.7
+        it "los resultados de multiplicaciones se redondean" $ do
+          (0.1 * 3) `shouldBeTheSameNumberAs` 0.3
+        it "los resultados de divisiones se redondean" $ do
+          (1 / 3) `shouldBeTheSameNumberAs` 0.333333333
+        it "no se pierde informacion al redondear en sucesivas operaciones" $ do
+          (1 / 3 * 3) `shouldBeTheSameNumberAs` 1
+        it "se redondea al usarse como parámetro de funciones que necesitan enteros" $ do
+          take 0.9999999999 [1,2,3,4] `shouldBe` [1]
 
 shouldBeTheSameNumberAs :: Number -> Number -> Expectation
 shouldBeTheSameNumberAs aNumber anotherNumber =


### PR DESCRIPTION
`RebindableSyntax` hace necesario que se exporte `ifThenElse` para poder usar expresiones `if then else`, si no GHC tira un error.

En este PR se agrega una definición de `ifThenElse` y se exporta desde el PdePreludat.