### PR TITLE
Show integer numbers without decimal digits

### DIFF
--- a/src/Number.hs
+++ b/src/Number.hs
@@ -20,9 +20,11 @@ type WrappedNum = P.Double
 numberToIntegral :: (P.Integral a) => Number -> a
 numberToIntegral (Number number) | isFractional roundedNumber = P.error notAnIntegralErrorMessage
                                  | P.otherwise = P.floor roundedNumber
-    where isFractional numero = P.floor numero P./= P.ceiling numero
-          roundedNumber = roundWrappedNum number
+    where roundedNumber = roundWrappedNum number
           notAnIntegralErrorMessage = "Se esperaba un valor entero pero se pasó uno con decimales: " P.++ P.show (Number number)
+
+isFractional :: WrappedNum -> P.Bool
+isFractional numero = P.floor numero P./= P.ceiling numero
 
 numberToFractional :: (P.Fractional a) => Number -> a
 numberToFractional = P.realToFrac
@@ -63,4 +65,6 @@ instance P.Eq Number where
     Number a == Number b = roundWrappedNum a P.== roundWrappedNum b
 
 instance P.Show Number where
-    show (Number x) = P.show $ roundWrappedNum x
+    show (Number number) | isFractional roundedNumber = P.show $ roundedNumber
+                         | P.otherwise = P.show $ P.floor $ roundedNumber
+        where roundedNumber = roundWrappedNum number

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -18,13 +18,19 @@ type WrappedNum = P.Double
 -- Funciones para convertir entre Number y los Num del Prelude
 
 numberToIntegral :: (P.Integral a) => Number -> a
-numberToIntegral (Number number) | isFractional roundedNumber = P.error notAnIntegralErrorMessage
-                                 | P.otherwise = P.floor roundedNumber
-    where roundedNumber = roundWrappedNum number
-          notAnIntegralErrorMessage = "Se esperaba un valor entero pero se pasó uno con decimales: " P.++ P.show (Number number)
+numberToIntegral number = case rounded number of
+    Integer integer -> P.fromInteger integer
+    Decimal _ -> P.error $ "Se esperaba un valor entero pero se pasó uno con decimales: " P.++ P.show number
 
-isFractional :: WrappedNum -> P.Bool
-isFractional numero = P.floor numero P./= P.ceiling numero
+-- El numero pero redondeado y ya conociendo si es entero o decimal
+
+data RoundedNumber = Integer P.Integer | Decimal WrappedNum
+
+rounded :: Number -> RoundedNumber
+rounded (Number number) | isFractional = Decimal roundedNumber
+                        | P.otherwise = Integer $ P.floor roundedNumber
+    where isFractional = P.floor roundedNumber P./= P.ceiling roundedNumber
+          roundedNumber = roundWrappedNum number
 
 numberToFractional :: (P.Fractional a) => Number -> a
 numberToFractional = P.realToFrac
@@ -65,6 +71,6 @@ instance P.Eq Number where
     Number a == Number b = roundWrappedNum a P.== roundWrappedNum b
 
 instance P.Show Number where
-    show (Number number) | isFractional roundedNumber = P.show $ roundedNumber
-                         | P.otherwise = P.show $ P.floor $ roundedNumber
-        where roundedNumber = roundWrappedNum number
+    show number = case rounded number of
+        Integer integer -> P.show integer
+        Decimal decimal -> P.show decimal

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -15,9 +15,14 @@ main = hspec $ do
     describe "Number" $ do
       it "dividir por 0 lanza error" $ do
         shouldThrowError $ 1 / 0
+      describe "Show" $ do
+        it "mostrar un numero entero no muestra los decimales" $ do
+          show 1 `shouldBe` "1"
+        it "mostrar un numero decimal incluye la parte decimal" $ do
+          show 1.5 `shouldBe` "1.5"
       describe "redondea a 9 decimales para compensar errores de punto flotante" $ do
         it "los numeros con muchos decimales se muestran redondeados" $ do
-          show 0.9999999999 `shouldBe` "1.0"
+          show 0.9999999999 `shouldBe` "1"
         it "los decimales literales se redondean" $ do
           0.9999999999 `shouldBeTheSameNumberAs` 1
         it "los resultados de sumas se redondean" $ do


### PR DESCRIPTION
## Qué

Queremos que cuando muestro un número que es entero, lo muestre sin la coma y los digitos decimales, o sea:

```hs
> show 1
1
> show 5.3
5.3
```

## Cómo

Agregué un tipo nuevo, `RoundedNumber` y una función para obtener un RoundedNumber a partir de un Number. Cumple una doble función:
Saber si el Number es entero o decimal, y asegurarme que ya está redondeado. Esto es para evitar el patrón de tener que redondear por un lado y luego hacer un if por si es fractional o no, ahora con la funcion `rounded` ya hago ese paso y el valor del resultado me indica si es entero o decimal.

Con eso las definiciones de `numberToIntegral` y `show`, en las que tengo que tener en cuenta si el valor es decimal o entero, creo que quedan más simples.

## Tests

Agregué un test para el show, y modifiqué uno de los tests que ahora se romperían porque cambio como mostramos algunos números.