### PR TITLE
Set other modules to none for library

### DIFF
--- a/the-template/package.yaml
+++ b/the-template/package.yaml
@@ -30,6 +30,7 @@ default-extensions:
 
 library:
   source-dirs: src
+  other-modules: []
 
 tests:
   the-template-test:


### PR DESCRIPTION
##  The Problem

`proyecto-test` is a project created by following https://github.com/10Pines/pdepreludat#preparar-proyecto : 
`stack new proyecto-test https://github.com/10Pines/pdepreludat/releases/download/2.0.5/pdepreludat.hsfiles`

Notice how it loads a module called Paths_proyecto_test and how asking the type to a number shows `Num p => p` (prelude's behaviour) instead of `Number` (pdepreludat's behaviour)
![image](https://user-images.githubusercontent.com/11432672/111079353-6d827280-84d8-11eb-913d-ee6a3641669a.png)


## Why this happened

It seems that in one of the latest versions of hpack, when generating the cabal file from the package.yaml a module called Path_proyectname was being added to `other-modules`. That module is loaded when you run `stack ghci` at the root of the project.

It's usually not problematic but in our case it is. This is because that module is importing the Prelude and we don't want that to happen because we are already providing an alternative Prelude.

## Solution

We set other-modules to [] instead of the [recommended solution](https://github.com/sol/hpack#handling-of-paths_-modules) because that solution implied writing the project name in the package yaml with _ instead of - (so if the project name was test-project it'd have to be written as test_project in the package.yaml). And that was kind of a pain to add to the template.

![image](https://user-images.githubusercontent.com/11432672/111079444-d2d66380-84d8-11eb-8c89-8dd3f931e869.png)

## What can I do if I already have a project set up and it has this problem?

If you created a PdePreludat project before this fix, what you need to do is:
- Delete the `PROJECT_NAME.cabal` file
- Add `other-modules: []` under `library:` in the `package.yaml`
- That's it ✅ 