### PR TITLE
Fixes #15 - Comportamiento del enum from then to

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ module Main where
 import PdePreludat
 import Test.Hspec
 import Control.Exception (evaluate)
+import qualified Prelude
 
 main :: IO ()
 main = hspec $ do
@@ -38,10 +39,43 @@ main = hspec $ do
         it "se redondea al usarse como parámetro de funciones que necesitan enteros" $ do
           take 0.9999999999 [1,2,3,4] `shouldBe` [1]
 
+    describe "enumFromThenTo" $ do
+      describe "cuando todos los numeros son enteros" $ do
+        it "devuelve una lista del primero al ultimo inclusive usando como salto entre cada numero la diferencia entre los dos primeros" $ do
+          [1, 2 .. 5] `shouldBe` [1, 2, 3, 4, 5]
+          [0, 2 .. 4] `shouldBe` [0, 2, 4]
+          [0, 2 .. 5] `shouldBe` [0, 2, 4]
+
+          [-1, -2 .. -5] `shouldBe` [-1, -2, -3, -4, -5]
+          [0, -2 .. -4] `shouldBe` [0, -2, -4]
+          [0, -2 .. -5] `shouldBe` [0, -2, -4]
+
+          [4, 3 .. 1] `shouldBe` [4 , 3, 2, 1]
+          [4, 2 .. 1] `shouldBe` [4 , 2]
+          [1 .. 10] `shouldBe` [1,2,3,4,5,6,7,8,9,10]
+      describe "cuando hay numeros decimales" $ do
+        -- El comportamiento de este caso está sacado de acá:
+        -- https://www.haskell.org/onlinereport/basic.html
+        -- For Float and Double, the semantics of the enumFrom family is given by the rules for Int above,
+        -- except that the list terminates when the elements become greater than e3+i/2 for positive increment i,
+        -- or when they become less than e3+i/2 for negative i.
+        it "devuelve una lista del primero al ultimo usando como salto entre cada numero la diferencia entre los dos primeros, la lista termina cuando aparece un elemento cuyo valor es más grande que el tercer parámetro + la mitad del salto" $ do
+          [1, 2 .. 5.5] `shouldBe` [1, 2, 3, 4, 5, 6]
+          [1, 2.5 .. 5.5] `shouldBe` [1, 2.5, 4, 5.5]
+          [0, 2 .. 5.5] `shouldBe` [0, 2, 4, 6]
+          [0, 2.5 .. 5.5] `shouldBe` [0, 2.5, 5]
+
+          [5, 4 .. 1.5] `shouldBe` [5, 4, 3, 2, 1]
+          [5.5, 4 .. 1.5] `shouldBe` [5.5, 4, 2.5, 1]
+          [5.5, 4 .. 1] `shouldBe` [5.5, 4, 2.5, 1]
+
+
+
 shouldBeTheSameNumberAs :: Number -> Number -> Expectation
 shouldBeTheSameNumberAs aNumber anotherNumber =
   (aNumber `shouldBe` anotherNumber) <>
   (aNumber < anotherNumber `shouldBe` False) <>
   (aNumber > anotherNumber `shouldBe` False)
 
+shouldThrowError :: a -> Expectation
 shouldThrowError expresion = evaluate expresion `shouldThrow` anyException


### PR DESCRIPTION
## Problem

The behaviour of lists defined with range syntax is not obvious when using decimal numbers in Haskell, and since the PdePreludat uses decimal values for all numbers this behaviour happened even if all the numbers in the list where integers:

![image](https://user-images.githubusercontent.com/11432672/111082624-0c629b00-84e8-11eb-8334-843b00ac8cf1.png)

## Why this happens?

It's explained in this spec: https://www.haskell.org/onlinereport/basic.html, 
```
 For the types Int and Integer, the enumeration functions have the following meaning:

    The sequence enumFrom e1 is the list [e1,e1+1,e1+2,...].

    The sequence enumFromThen e1 e2 is the list [e1,e1+i,e1+2i,...], where the increment, i, is e2-e1. The increment may be zero or negative. If the increment is zero, all the list elements are the same.

    The sequence enumFromTo e1 e3 is the list [e1,e1+1,e1+2,...e3]. The list is empty if e1 > e3.

    The sequence enumFromThenTo e1 e2 e3 is the list [e1,e1+i,e1+2i,...e3], where the increment, i, is e2-e1. If the increment is positive or zero, the list terminates when the next element would be greater than e3; the list is empty if e1 > e3. If the increment is negative, the list terminates when the next element would be less than e3; the list is empty if e1 < e3. 

For Float and Double, the semantics of the enumFrom family is given by the rules for Int above, except that the list terminates when the elements become greater than e3+i/2 for positive increment i, or when they become less than e3+i/2 for negative i.
```

EnumFromThenTo generates values in the list not until there's a value higher/lower than the last parameter, but when it gets a value that is at more than half a step of distance from that last parameter.

## Solution

Keep the same behaviour for decimals because it could make sense when dealing with rounding and also to keep the PdePreludat similar to Prelude there. However, when all the parameters are integers (have an empty decimal part) then have enumFromThenTo behave as it behaves for integers.