### PR TITLE
Usar imagenes del repo como documentacion de funciones

### DIFF
--- a/src/Redefinitions.hs
+++ b/src/Redefinitions.hs
@@ -627,7 +627,7 @@ pi = P.pi
 
 -- | Devuelve el valor de la función exponencial e^x, pasando como parámetro la __x__
 --
--- <<https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Exponentials.svg/1024px-Exponentials.svg.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/exp.png>>
 --
 -- >>> exp 0
 -- 1
@@ -642,7 +642,7 @@ exp = P.exp
 
 -- | Devuelve el logaritmo en base 10 de un número.
 --
--- <<https://upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Graph_of_common_logarithm.svg/1200px-Graph_of_common_logarithm.svg.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/log.png>>
 -- 
 -- >>> log 149
 -- 5.003946306
@@ -670,7 +670,7 @@ sqrt = P.sqrt
 
 -- | Dados dos números (__x__ e __y__), devuelve el logaritmo en base __x__ del número __y__.
 --
--- <<https://cdn-amccl.nitrocdn.com/JSubMagokulfBnGCVBTqbGYgsRhlCXZq/assets/static/optimized/rev-2d1feb6/escuela/wp-content/uploads/2020/09/Logarithm_plots.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/logBase.png>>
 -- 
 -- >>> logBase 10 10
 -- 1
@@ -682,7 +682,7 @@ logBase = P.logBase
 
 -- | Devuelve la función seno de un número.
 --
--- <<https://www.montereyinstitute.org/courses/DevelopmentalMath/TEXTGROUP-15-19_RESOURCE/U19_L2_T2_text_final_files_es/image082.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/sin.png>>
 --
 -- >>> sin pi
 -- 0
@@ -694,7 +694,7 @@ sin = P.sin
 
 -- | Devuelve la función coseno de un número.
 --
--- <<https://www.universoformulas.com/imagenes/matematicas/trigonometria/grafica-coseno.jpg>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/cos.png>>
 --
 -- >>> cos pi
 -- -1
@@ -706,7 +706,7 @@ cos = P.cos
 
 -- | Devuelve la función tangente de un número.
 --
--- <<https://www.universoformulas.com/imagenes/matematicas/trigonometria/grafica-tangente.jpg>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/tan.png>>
 --
 -- >>> tan pi
 -- 0
@@ -718,7 +718,7 @@ tan = P.tan
 
 -- | Devuelve la función arcoseno de un número.
 --
--- <<https://www.universoformulas.com/imagenes/matematicas/trigonometria/grafica-arcoseno-simetrica-seno.jpg>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/asin.png>>
 --
 -- >>> asin 1
 -- 1.570796327
@@ -727,7 +727,7 @@ asin = P.asin
 
 -- | Devuelve la función arcocoseno de un número.
 --
--- <<https://www.universoformulas.com/imagenes/matematicas/trigonometria/grafica-arcocoseno-coseno.jpg>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/acos.png>>
 --
 -- >>> acos 0
 -- 1.570796327
@@ -736,7 +736,7 @@ acos = P.acos
 
 -- | Devuelve la función arcotangente de un número.
 --
--- <<https://www.universoformulas.com/imagenes/matematicas/trigonometria/grafica-arcotangente-simetrica-tangente.jpg>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/atan.png>>
 --
 -- >>> atan 1
 -- 0.785398163
@@ -745,7 +745,7 @@ atan = P.atan
 
 -- | Devuelve la función seno hiperbólico de un número.
 --
--- <<https://upload.wikimedia.org/wikipedia/commons/3/3a/Sinh_plot_real.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/sinh.png>>
 --
 -- >>> sinh 1
 -- 1.175201194
@@ -754,7 +754,7 @@ sinh = P.sinh
 
 -- | Devuelve la función coseno hiperbólico de un número.
 --
--- <<https://miprofe.com/wp-content/uploads/2016/04/coseno-hiperbolico-273x300.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/cosh.png>>
 --
 -- >>> cosh 0
 -- 1
@@ -763,7 +763,7 @@ cosh = P.cosh
 
 -- | Devuelve la función tangente hiperbólica de un número.
 --
--- <<https://miprofe.com/wp-content/uploads/2016/04/tangente-hiperbolica-274x300.png>>
+-- <<https://raw.githubusercontent.com/10Pines/pdepreludat/f7678b7c0da45d2a9c7a4d0b00380f45b8457a1c/images/tanh.png>>
 --
 -- >>> tanh 0
 -- 0


### PR DESCRIPTION
Siguiendo lo del PR anterior #31 , en este se linkea a las imagenes subidas para que se muestren como documentacion.