### PR TITLE
Reorganize template to have specs on the same cabal component as library code

### DIFF
--- a/the-template/package.yaml
+++ b/the-template/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - pdeprelude
+- hspec
 
 default-extensions:
   - NoImplicitPrelude
@@ -34,7 +35,7 @@ library:
 
 tests:
   the-template-test:
-    main:                Spec.hs
+    main:                CorrerTests.hs
     source-dirs:         test
     ghc-options:
     - -threaded
@@ -42,4 +43,4 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - the-template
-    - hspec
+

--- a/the-template/src/Spec.hs
+++ b/the-template/src/Spec.hs
@@ -1,9 +1,10 @@
+module Spec where
 import PdePreludat
 import Library
 import Test.Hspec
 
-main :: IO ()
-main = hspec $ do
+correrTests :: IO ()
+correrTests = hspec $ do
   describe "Test de ejemplo" $ do
     it "El pdepreludat se instaló correctamente" $ do
       doble 1 `shouldBe` 2

--- a/the-template/test/CorrerTests.hs
+++ b/the-template/test/CorrerTests.hs
@@ -1,0 +1,5 @@
+import Spec
+import PdePreludat
+
+main :: IO ()
+main = correrTests


### PR DESCRIPTION
By moving all the code into one component we avoid problems of dependencies between the components like what we experienced with HLS (needing to build and then restart the haskell language server) and with Simple GHC (having to choose the correct target to get the tests compiling in vscode).

The only thing that the test code does is evaluating the expression `correrTests`, which actually runs hspec.

There is just one downside which is that running `stack ghci` shows a bit more stuff in the prompt:

```
*Spec Library Spec> 
``` 