### PR TITLE
Simplificar hie.yaml para Simple GHC en Windows

### DIFF
--- a/the-template/hie.yaml
+++ b/the-template/hie.yaml
@@ -1,7 +1,2 @@
 cradle:
   stack:
-    - path: "./src"
-      component: "the-template:lib"
-
-    - path: "./test"
-      component: "the-template:test:the-template-test"


### PR DESCRIPTION
Maiu se dio cuenta de que en Windows Simple GHC no funcionaba bien y pareciera ser por esto:
https://github.com/dramforever/vscode-ghc-simple/issues/91

El yaml con el contenido que tiene ahora funciona bien tanto en hls (sin tirar warnings, que por ej. si los tira si no hay hie.yaml) como en simple ghc