### PR TITLE
Avoid WARNING message for guarded equations

### DIFF
--- a/the-template/src/Library.hs
+++ b/the-template/src/Library.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 module Library where
 import PdePreludat
 

--- a/the-template/src/Spec.hs
+++ b/the-template/src/Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 module Spec where
 import PdePreludat
 import Library


### PR DESCRIPTION
## Issue
We are currently experiencing a strange warning message whenever you try to use a guarded equation. We want to fix that.

![image](https://user-images.githubusercontent.com/4549002/155984751-60ab980d-5239-482e-9d2d-32f7c09e0045.png)

## Solution
Add pragma on both `Library.hs` and `Spec.hs` files.