### PR TITLE
Solución para issue #39

### DIFF
--- a/src/Number.hs
+++ b/src/Number.hs
@@ -34,12 +34,12 @@ instance P.Num WrappedNum where
     Right x * Left y  = toWrapped (x P.* P.fromIntegral y)
 
     abs = bimap P.abs P.abs
-    signum = bimap P.signum P.signum
+    signum = either (Left . P.signum) (toWrapped . P.signum)
     fromInteger = Left
     negate = bimap P.negate P.negate
 
 instance P.Real WrappedNum where
-    toRational = P.either P.toRational P.toRational
+    toRational = either P.toRational P.toRational
 
 instance P.Fractional WrappedNum where
     fromRational x = case (P.== numberToIntegral 1) . denominator $ x of

--- a/src/Number.hs
+++ b/src/Number.hs
@@ -20,7 +20,8 @@ newtype Number = Number { wrappedNum :: WrappedNum }
 
 type WrappedNum = Either P.Integer P.Double
 
--- When applying a binary operator to an Integer and a Double, automatically returns Double
+-- Instancias de typeclasses numéricas
+
 instance P.Num WrappedNum where
     Left x  + Left y  = Left (x P.+ y)
     Right x + Right y = toWrapped (x P.+ y)
@@ -127,11 +128,11 @@ roundToWrap = roundingTo digitsToCheckIfInteger
 roundToWrap' :: P.Double -> P.Double
 roundToWrap' = roundingTo digitsAfterComma
 
-digitsAfterComma :: P.Integer
-digitsAfterComma = numberToIntegral 10
-
 digitsToCheckIfInteger :: P.Integer
 digitsToCheckIfInteger = numberToIntegral 9
+
+digitsAfterComma :: P.Integer
+digitsAfterComma = numberToIntegral 10
 
 roundingTo :: P.Integer -> P.Double -> P.Double
 roundingTo n = (P./ exp) . P.fromIntegral . P.round . (P.* exp)
@@ -147,9 +148,6 @@ instance P.Eq Number where
     Number a == Number b = a P.== b
 
 instance P.Show Number where
-    -- show (Number number) = case number of
-    --     Left integer -> P.show integer
-    --     Right decimal -> P.show decimal
     show = either P.show P.show . wrappedNum
 
 instance P.Enum Number where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -21,6 +21,8 @@ main = hspec $ do
           show 1 `shouldBe` "1"
         it "mostrar un numero decimal incluye la parte decimal" $ do
           show 1.5 `shouldBe` "1.5"
+        it "números enteros más allá de la precisión de Double se muestran correctamente" $ do
+          show 12345678901234567890 `shouldBe` "12345678901234567890"
       describe "redondea a 9 decimales para compensar errores de punto flotante" $ do
         it "los numeros con muchos decimales se muestran redondeados" $ do
           show 0.9999999999 `shouldBe` "1"


### PR DESCRIPTION
¡Buenas noches! Ante unas imprecisiones que surgen con el manejo de números muy grandes con el tipo Number, dejo una propuesta para poder soportar estos números y a la vez seguir soportando la representación con punto flotante.
Básicamente consiste en que Number encierre un valor de tipo `Either Integer Double`, y a la hora de resolver una función devuelva el tipo correspondiente de estos dos. Esto implica que la conversión se hace por cada operación, por lo tanto para que dé el test:
```Haskell
it "no se pierde informacion al redondear en sucesivas operaciones" $ do
(1 / 3 * 3) `shouldBeTheSameNumberAs` 1
```
Mi solución fue que, al representarlo como Double, se redondee a 10 decimales, pero al chequear si debe ser convertido a Int se redondee a 9. De esta manera:
```Haskell
>>> 1 / 3 * 3
>>> 0,3333333333 * 3 -- este primer resultado no se convierte a Integer, por lo tanto queda representado con 10 decimales
>>> 0,9999999999 -- este resultado sí se convierte a Integer porque, redondeado a 9 decimales, da 1
>>> 1
```
Surge una limitación al operar un Number que es Integer con un Number que es Double. Para preservar el valor de los decimales, hay que convertir el Integer a Double, lo cual naturalmente hace que se pierda la precisión extra del Integer para números muy grandes (que sólo se mantiene al operar entre Integers y con funciones como show).
Además, agregué un test en la línea 24 para verificar que un número que antes no se podía representar ahora sí puede ser representado.
Aclaración: este test ahora no pasa:
```Haskell
it "los resultados de divisiones se redondean" $ do
(1 / 3) `shouldBeTheSameNumberAs` 0.333333333
```
Pero es por el cambio que mencioné más arriba. Ahora, la cuenta arroja un decimal más (10 en vez de 9).