### PR TITLE
add new ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,21 +5,12 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
-      - uses: actions/cache@v3
-        name: Cache ~/.stack
+      - name: Cache Dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-global-
-      - uses: actions/cache@v3
-        name: Cache .stack-work
-        with:
-          path: .stack-work
-          key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-work-
-
+          path: /home/runner
+          key: ${{ runner.os }}-runner
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,4 @@ jobs:
         if: always()
         with:
           path: ${{ steps.setuphaskell.outputs.stack-root }}
-          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2            
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,22 +3,57 @@ name: build
 jobs:
   runhaskell:
     name: Run Haskell
-    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        snapshot:
+          - 'lts-22.13'
     steps:
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v4
+      - uses: haskell-actions/setup@main
+        name: Setup Haskell Stack
+        id: setuphaskell
         with:
-          path: /home/runner
-          key: ${{ runner.os }}-runner
-      - uses: actions/checkout@v4
-      - uses: haskell-actions/setup@v2
-        with:
-          ghc-version: '9.6.4' # Exact version of ghc to use
-          cabal-version: '3.10.2.1'
           enable-stack: true
-          stack-version: '2.13.1'
-      - run: stack test
+          stack-no-global: true
+      - uses: actions/cache/restore@v3
+        name: Cache stack files
+        with:
+          path: ${{ steps.setuphaskell.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
+      - uses: actions/checkout@v4
+
+      - name: Setup stack.yaml
+        shell: bash
+        run: |
+          set -x
+          mv -vf "stack-ci.yaml" ./stack.yaml || true
+          mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
+          mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
+
+      - name: Build and test
+        shell: bash
+        run: |
+          set -x
+          grep . stack.yaml
+          if grep SKIP stack.yaml; then
+            echo Skipped because that snapshot is broken
+            exit 0
+          fi
+          stack setup --resolver=${{ matrix.snapshot }}
+          echo "stack_root: ${{ steps.setuphaskell.outputs.stack-root }}"
+          stack --version
+          stack --resolver=${{ matrix.snapshot }} ghc -- --version
+
+          # we first build everything without running the tests (with unlimited parallelism)
+          stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench --no-run-tests
+
+          # once that's done we run the tests in a single threaded fashion to avoid
+          # https://github.com/commercialhaskell/stack/issues/5024#issuecomment-845001389
+          stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1
+
       - run: ./build_hsfiles.sh > pdepreludat.hsfiles
       - uses: "marvinpinto/action-automatic-releases@latest"
         if: github.ref == 'refs/heads/master'
@@ -29,3 +64,8 @@ jobs:
           title: "Draft"
           files: |
             pdepreludat.hsfiles
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ steps.setuphaskell.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,37 +5,13 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
-      # things to be cached/restored:
-      - name: Cache stack global package db
-        id:   stack-global
-        uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: haskell-actions/setup@v2
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-global-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-global-${{ matrix.plan.ghc }}
-      - name: Cache stack-installed programs in ~/.local/bin
-        id:   stack-programs
-        uses: actions/cache@v2
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-stack-programs-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-programs-${{ matrix.plan.ghc }}
-      - name: Cache .stack-work
-        uses: actions/cache@v2
-        with:
-          path: .stack-work
-          key: ${{ runner.os }}-stack-work-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-work-${{ matrix.plan.ghc }}
-      # end cache configuration
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
-        with:
-          # cabal-version: 'latest'. Omitted, but defalts to 'latest'
+          ghc-version: '9.6.4' # Exact version of ghc to use
+          cabal-version: '3.10.2.1'
           enable-stack: true
-          stack-version: 'latest'
+          stack-version: '2.13.1'
       - run: stack test
       - run: ./build_hsfiles.sh > pdepreludat.hsfiles
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: '9.6.4' # Exact version of ghc to use

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,21 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v4
+      - uses: actions/cache@v3
+        name: Cache ~/.stack
         with:
-          path: /home/runner
-          key: ${{ runner.os }}-runner
+          path: ~/.stack
+          key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-global-
+      - uses: actions/cache@v3
+        name: Cache .stack-work
+        with:
+          path: .stack-work
+          key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work-
+
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           enable-stack: true
           stack-no-global: true
+
       - uses: actions/cache/restore@v3
         name: Cache stack files
         with:
@@ -55,6 +56,7 @@ jobs:
           stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1
 
       - run: ./build_hsfiles.sh > pdepreludat.hsfiles
+
       - uses: "marvinpinto/action-automatic-releases@latest"
         if: github.ref == 'refs/heads/master'
         with:
@@ -64,6 +66,7 @@ jobs:
           title: "Draft"
           files: |
             pdepreludat.hsfiles
+            
       - uses: actions/cache/save@v3
         if: always()
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
+      - name: Cache Dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: /home/runner
+          key: ${{ runner.os }}-runner
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:

--- a/the-template/.github/workflows/build.yml
+++ b/the-template/.github/workflows/build.yml
@@ -48,10 +48,7 @@ jobs:
           stack --version
           stack --resolver=${{ matrix.snapshot }} ghc -- --version
 
-          # we first build everything without running the tests (with unlimited parallelism)
-          stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench --no-run-tests
-
-          # once that's done we run the tests in a single threaded fashion to avoid
+          # we run the tests in a single threaded fashion to avoid
           # https://github.com/commercialhaskell/stack/issues/5024#issuecomment-845001389
           stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1
 

--- a/the-template/.github/workflows/build.yml
+++ b/the-template/.github/workflows/build.yml
@@ -6,6 +6,12 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
+      - name: Cache Dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: /home/runner
+          key: ${{ runner.os }}-runner
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:

--- a/the-template/.github/workflows/build.yml
+++ b/the-template/.github/workflows/build.yml
@@ -6,36 +6,12 @@ jobs:
     name: Run Haskell
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
-      # things to be cached/restored:
-      - name: Cache stack global package db
-        id:   stack-global
-        uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-global-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-global-${{ matrix.plan.ghc }}
-      - name: Cache stack-installed programs in ~/.local/bin
-        id:   stack-programs
-        uses: actions/cache@v2
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-stack-programs-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-programs-${{ matrix.plan.ghc }}
-      - name: Cache .stack-work
-        uses: actions/cache@v2
-        with:
-          path: .stack-work
-          key: ${{ runner.os }}-stack-work-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack-work-${{ matrix.plan.ghc }}
-      # end cache configuration
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
-        with:
-          # cabal-version: 'latest'. Omitted, but defalts to 'latest'
+          ghc-version: '9.6.4' # Exact version of ghc to use
+          cabal-version: '3.10.2.1'
           enable-stack: true
-          stack-version: 'latest'
+          stack-version: '2.13.1'
       - run: stack test
 # <%={{ }}=%>

--- a/the-template/.github/workflows/build.yml
+++ b/the-template/.github/workflows/build.yml
@@ -19,11 +19,14 @@ jobs:
         with:
           enable-stack: true
           stack-no-global: true
+          stack-version: '2.13.1'
+
       - uses: actions/cache/restore@v3
         name: Cache stack files
         with:
           path: ${{ steps.setuphaskell.outputs.stack-root }}
           key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
+
       - uses: actions/checkout@v4
 
       - name: Setup stack.yaml

--- a/the-template/.github/workflows/build.yml
+++ b/the-template/.github/workflows/build.yml
@@ -4,20 +4,70 @@ name: build
 jobs:
   runhaskell:
     name: Run Haskell
-    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        snapshot:
+          - 'lts-22.13'
     steps:
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v4
+      - uses: haskell-actions/setup@main
+        name: Setup Haskell Stack
+        id: setuphaskell
         with:
-          path: /home/runner
-          key: ${{ runner.os }}-runner
-      - uses: actions/checkout@v4
-      - uses: haskell-actions/setup@v2
-        with:
-          ghc-version: '9.6.4' # Exact version of ghc to use
-          cabal-version: '3.10.2.1'
           enable-stack: true
-          stack-version: '2.13.1'
-      - run: stack test
+          stack-no-global: true
+      - uses: actions/cache/restore@v3
+        name: Cache stack files
+        with:
+          path: ${{ steps.setuphaskell.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
+      - uses: actions/checkout@v4
+
+      - name: Setup stack.yaml
+        shell: bash
+        run: |
+          set -x
+          mv -vf "stack-ci.yaml" ./stack.yaml || true
+          mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
+          mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
+
+      - name: Build and test
+        shell: bash
+        run: |
+          set -x
+          grep . stack.yaml
+          if grep SKIP stack.yaml; then
+            echo Skipped because that snapshot is broken
+            exit 0
+          fi
+          stack setup --resolver=${{ matrix.snapshot }}
+          echo "stack_root: ${{ steps.setuphaskell.outputs.stack-root }}"
+          stack --version
+          stack --resolver=${{ matrix.snapshot }} ghc -- --version
+
+          # we first build everything without running the tests (with unlimited parallelism)
+          stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench --no-run-tests
+
+          # once that's done we run the tests in a single threaded fashion to avoid
+          # https://github.com/commercialhaskell/stack/issues/5024#issuecomment-845001389
+          stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1
+
+      - run: ./build_hsfiles.sh > pdepreludat.hsfiles
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/master'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "draft"
+          prerelease: true
+          title: "Draft"
+          files: |
+            pdepreludat.hsfiles
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ steps.setuphaskell.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
 # <%={{ }}=%>


### PR DESCRIPTION
bueno los taggeo @ludat @JuanFdS , al final usando la variante de Conferer hay que poner el LTS. Dentro del pdepreludat dejé que use la versión más reciente de stack. Para el template no quiero arriesgarme: hay varios docentes que no se animan a usarlo y meter una versión diferente en el CI que la que usan los pibes es algo que puede traer problemas (teniendo en cuenta que los pibes no tocan el archivo de dependencias de stack ni hay cambios esperables durante el año).

Con la cache bajó del minuto el build del CI, lo que dejamos como consulta a vos Ludat que la tenés más clara es: se puede armar una cache global a nivel organización de github? Porque estaría piola que el primer commit no tarde 4 ó 5 minutos la primera vez para cada repo nuevo...

![image](https://github.com/10Pines/pdepreludat/assets/4549002/7eff4571-8fa6-45a4-b483-351bca7b315d)





