### PR TITLE
Reemplazar typeerror por unsatisfiable

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ extra-source-files:
 description:         Please see the README on GitHub at <https://github.com/githubuser/pdeprelude#readme>
 
 dependencies:
-- base >= 4.7 && < 5
+- base >= 4.19 && < 5
 - pretty-simple
 
 default-extensions:

--- a/pdeprelude.cabal
+++ b/pdeprelude.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fa032a2e5ae55a22fd1f4907cd1daa2b116936c9aa30d5086cbe4cd6611285fc
+-- hash: 0d9cf642edf9767476494886655133e32370b543cf80ce75b62038f95cc6b389
 
 name:           pdeprelude
 version:        0.2.0.0
@@ -49,7 +49,7 @@ library
       DerivingVia
   ghc-options: -Wno-missing-methods
   build-depends:
-      base >=4.7 && <5
+      base >=4.19 && <5
     , pretty-simple
   default-language: Haskell2010
 
@@ -72,7 +72,7 @@ test-suite pdeprelude-test
       DerivingVia
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      base >=4.19 && <5
     , hspec
     , pdeprelude
     , pretty-simple

--- a/src/BetterErrors.hs
+++ b/src/BetterErrors.hs
@@ -1,55 +1,58 @@
-module BetterErrors where
-import Prelude
-import GHC.TypeLits
+{-# LANGUAGE FlexibleContexts #-}
 
---- Para funciones
+module BetterErrors where
+
+import Prelude
+import GHC.TypeError
+
+-- Para funciones
 
 type ErrorNumeroXFuncion = Text "Estás usando una función como un número o un número como una función."
 type ErrorOrdenableXFuncion = Text "Las funciones no se pueden ordenar ni comparar."
 type ErrorEnumerableXFuncion = Text "Las funciones no son enumerables."
 
-instance TypeError ErrorNumeroXFuncion => Num (a -> b)
-instance TypeError ErrorOrdenableXFuncion => Ord (a -> b)
-instance TypeError ErrorOrdenableXFuncion => Eq (a -> b)
-instance TypeError ErrorNumeroXFuncion => Floating (a -> b)
-instance TypeError ErrorNumeroXFuncion => Fractional (a -> b)
-instance (TypeError ErrorNumeroXFuncion,
-          TypeError ErrorEnumerableXFuncion,
-          TypeError ErrorOrdenableXFuncion) => Integral (a -> b)
-instance (TypeError ErrorNumeroXFuncion, TypeError ErrorOrdenableXFuncion) => RealFrac (a -> b)
-instance (TypeError ErrorNumeroXFuncion, TypeError ErrorOrdenableXFuncion) => RealFloat (a -> b)
-instance (TypeError ErrorNumeroXFuncion, TypeError ErrorOrdenableXFuncion) => Real (a -> b)
-instance (TypeError ErrorEnumerableXFuncion) => Enum (a -> b)
+instance Unsatisfiable ErrorNumeroXFuncion => Num (a -> b)
+instance Unsatisfiable ErrorOrdenableXFuncion => Ord (a -> b)
+instance Unsatisfiable ErrorOrdenableXFuncion => Eq (a -> b)
+instance Unsatisfiable ErrorNumeroXFuncion => Floating (a -> b)
+instance Unsatisfiable ErrorNumeroXFuncion => Fractional (a -> b)
+instance (Unsatisfiable ErrorNumeroXFuncion,
+          Unsatisfiable ErrorEnumerableXFuncion,
+          Unsatisfiable ErrorOrdenableXFuncion) => Integral (a -> b)
+instance (Unsatisfiable ErrorNumeroXFuncion, Unsatisfiable ErrorOrdenableXFuncion) => RealFrac (a -> b)
+instance (Unsatisfiable ErrorNumeroXFuncion, Unsatisfiable ErrorOrdenableXFuncion) => RealFloat (a -> b)
+instance (Unsatisfiable ErrorNumeroXFuncion, Unsatisfiable ErrorOrdenableXFuncion) => Real (a -> b)
+instance (Unsatisfiable ErrorEnumerableXFuncion) => Enum (a -> b)
 
----Para listas
+-- Para listas
 type ErrorNumeroXLista = Text "Estás usando una lista como un número o un número como una lista."
 type ErrorEnumerableXLista = Text "Las listas no son enumerables."
 
-instance TypeError ErrorNumeroXLista => Num [a]
-instance TypeError ErrorNumeroXLista => Floating [a]
-instance TypeError ErrorNumeroXLista => Fractional [a]
-instance (Ord a, TypeError ErrorEnumerableXLista, TypeError ErrorNumeroXLista) => Integral [a]
-instance (Ord a, TypeError ErrorNumeroXLista) => RealFrac [a]
-instance (Ord a, TypeError ErrorNumeroXLista) => RealFloat [a]
-instance (Ord a, TypeError ErrorNumeroXLista) => Real [a]
-instance (TypeError ErrorNumeroXLista) => Enum [a]
+instance Unsatisfiable ErrorNumeroXLista => Num [a]
+instance Unsatisfiable ErrorNumeroXLista => Floating [a]
+instance Unsatisfiable ErrorNumeroXLista => Fractional [a]
+instance (Ord a, Unsatisfiable ErrorEnumerableXLista, Unsatisfiable ErrorNumeroXLista) => Integral [a]
+instance (Ord a, Unsatisfiable ErrorNumeroXLista) => RealFrac [a]
+instance (Ord a, Unsatisfiable ErrorNumeroXLista) => RealFloat [a]
+instance (Ord a, Unsatisfiable ErrorNumeroXLista) => Real [a]
+instance (Unsatisfiable ErrorNumeroXLista) => Enum [a]
 
----Para caracteres
+-- Para caracteres
 type ErrorNumeroXCaracter = Text "Estás usando una caracter como un número o un número como un caracter."
 
-instance TypeError ErrorNumeroXCaracter => Num Char
-instance TypeError ErrorNumeroXCaracter => Floating Char
-instance TypeError ErrorNumeroXCaracter => Fractional Char
-instance TypeError ErrorNumeroXCaracter => Integral Char
-instance TypeError ErrorNumeroXCaracter => RealFrac Char
-instance TypeError ErrorNumeroXCaracter => RealFloat Char
-instance TypeError ErrorNumeroXCaracter => Real Char
+instance Unsatisfiable ErrorNumeroXCaracter => Num Char
+instance Unsatisfiable ErrorNumeroXCaracter => Floating Char
+instance Unsatisfiable ErrorNumeroXCaracter => Fractional Char
+instance Unsatisfiable ErrorNumeroXCaracter => Integral Char
+instance Unsatisfiable ErrorNumeroXCaracter => RealFrac Char
+instance Unsatisfiable ErrorNumeroXCaracter => RealFloat Char
+instance Unsatisfiable ErrorNumeroXCaracter => Real Char
 
---Errores entre enteros y fraccionales
+-- Errores entre enteros y fraccionales
 type ErrorFraccionalXEntero =
     Text "Estás usando un entero como un decimal o viceversa, y los números enteros y decimales son de diferente tipo.\nPodés convertir el entero en decimal usando toFloat/1 o el decimal en entero usando round/1, floor/1 o ceiling/1.\n\nTambién, si querés leer mas al respecto:\nhttp://wiki.uqbar.org/wiki/articles/problemas-comunes-con-los-tipos-numericos-de-haskell.html\n"
 
-instance TypeError ErrorFraccionalXEntero => Fractional Int
-instance TypeError ErrorFraccionalXEntero => Fractional Integer
-instance TypeError ErrorFraccionalXEntero => Integral Float
-instance TypeError ErrorFraccionalXEntero => Integral Double
+instance Unsatisfiable ErrorFraccionalXEntero => Fractional Int
+instance Unsatisfiable ErrorFraccionalXEntero => Fractional Integer
+instance Unsatisfiable ErrorFraccionalXEntero => Integral Float
+instance Unsatisfiable ErrorFraccionalXEntero => Integral Double

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.43
+resolver: lts-23.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 08bd13ce621b41a8f5e51456b38d5b46d7783ce114a50ab604d6bbab0d002146
-    size: 720271
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/43.yaml
-  original: lts-22.43
+    sha256: 2763632e4c4094ce12f5ae12b22f524cdc6453b6b19007ff164a37fd9d2ea829
+    size: 683819
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/17.yaml
+  original: lts-23.17

--- a/the-template/stack.yaml
+++ b/the-template/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.43
+resolver: lts-23.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/the-template/stack.yaml.lock
+++ b/the-template/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 6f0bea3ba5b07360f25bc886e8cff8d847767557a492a6f7f6dcb06e3cc79ee9
-    size: 712905
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/13.yaml
-  original: lts-22.13
+    sha256: 2763632e4c4094ce12f5ae12b22f524cdc6453b6b19007ff164a37fd9d2ea829
+    size: 683819
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/17.yaml
+  original: lts-23.17


### PR DESCRIPTION
Fixes #47

https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0433-unsatisfiable.rst

Esto mueve los errores a tiempo de resolución de constraints lo que hace que sean mas predecibles.

# Parte mala

Esto tambien requiere que usemos base 4.19, lo que implica ghc 9.8 asi que seguramente quede para el año que viene