### PR TITLE
new release por tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,11 @@ jobs:
           title: "Draft"
           files: |
             pdepreludat.hsfiles
+      # ← NUEVO paso para releases con tags
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false          
+          files: |
+            pdepreludat.hsfiles


### PR DESCRIPTION
Agrego al CI el paso para crear un nuevo release con la creación del archivo .hsfiles bajo el evento de un push tag.

Actualmente solo corre la creación de draft con los push a master, por eso los tags no crean el .hsfiles. 